### PR TITLE
Use MIME library to determine file extension

### DIFF
--- a/lib/whatsapp_elixir/upload.ex
+++ b/lib/whatsapp_elixir/upload.ex
@@ -134,8 +134,8 @@ The `media_url` expires after 5 minutes. To download the file after the URL has 
 """
 def download_media(media_url, mime_type, file_path \\ "temp", custom_config \\ []) do
   extension =
-    case String.split(mime_type, "/") do
-      [_type, ext] -> ext
+    case MIME.extensions(mime_type) do
+      [ext | _] -> ext
       _ -> raise ArgumentError, "Invalid MIME type: #{mime_type}"
     end
 

--- a/mix.exs
+++ b/mix.exs
@@ -53,6 +53,7 @@ defmodule WhatsappElixir.MixProject do
       {:req, "~> 0.3"},
       {:jason, "~> 1.4"},
       {:multipart, "~> 0.4.0"},
+      {:mime, "~> 2.0.6"},
       {:ex_doc, "~> 0.27.0", only: :dev, runtime: false}
     ]
   end


### PR DESCRIPTION
Hi!
This PR improves parsing of the MIME types, by leveraging an external library. It was already a transient dependency of the project.

The parsing will improve, as the MIME types handling can be a bit trickier than simple splitting on the slash `"/"`. See for example that `"audio/mpeg"` maps to the `mp3` extensions, not `mpeg`: https://github.com/elixir-plug/mime/blob/30db90a63ca14732f9c6b9d733c89cd161451b15/lib/mime.ex#L87 and https://developer.mozilla.org/en-US/docs/Web/HTTP/MIME_types/Common_types.

This PR fixes https://github.com/Maxino22/whatsapp_elixir/issues/7 (by returning the `oga` extension):
```Elixir
iex> MIME.extensions("audio/ogg; codecs=opus")
["oga"]
```