### PR TITLE
Fix argument order

### DIFF
--- a/lib/whatsapp_elixir/upload.ex
+++ b/lib/whatsapp_elixir/upload.ex
@@ -52,7 +52,7 @@ defmodule WhatsappElixir.Upload do
       |> Multipart.add_part(Multipart.Part.text_field(
         "whatsapp", "messaging_product"
       ))
-      |> Multipart.add_part(Multipart.Part.text_field("type", mime_type))
+      |> Multipart.add_part(Multipart.Part.text_field(mime_type, "type"))
       |>  Multipart.add_part(
         Multipart.Part.file_content_field(filename, file_content, :file, filename: filename)
       )


### PR DESCRIPTION
Hi!
If I'm not mistaken, the order of arguments is wrong in the `Multipart.Part.text_field/2` call. [The docs](https://hexdocs.pm/multipart/Multipart.Part.html#text_field/3) say that `body` is the first argument, and `name` is the second one. This order would be similar to a call just before: https://github.com/Maxino22/whatsapp_elixir/blob/edf54edd9f96a6d3c77846775c734f8a6d63e2ca/lib/whatsapp_elixir/upload.ex#L53

See also https://developers.facebook.com/docs/whatsapp/cloud-api/messages/image-messages: the `"type"` is a key (name), same as `"messaging_product"`, so it should also be the second argument in the `Multipart.Part.text_field/2` call.

Maybe I'm wrong, but I think currently the upload media call sends `"image/png": "type"` in its body to Facebook, instead of `"type": "image/png"`.