### PR TITLE
Fixed Req decoding the body for get request

### DIFF
--- a/lib/whatsapp_elixir/http.ex
+++ b/lib/whatsapp_elixir/http.ex
@@ -84,7 +84,11 @@ defmodule WhatsappElixir.HTTP do
           {:error, reason}
       end
     else
-      case Req.post(url, body: Jason.encode!(body), headers: headers(token, content_type)) do
+      case Req.post(url,
+             body: Jason.encode!(body),
+             decode_body: false,
+             headers: headers(token, content_type)
+           ) do
         {:ok, %Response{status: status, body: body}} when status in 200..299 ->
           {:ok, Jason.decode!(body)}
 
@@ -143,7 +147,7 @@ defmodule WhatsappElixir.HTTP do
 
     Logger.info("Constructed URL: #{full_url}")
 
-    case Req.get(full_url, headers: headers(token)) do
+    case Req.get(full_url, decode_body: false, headers: headers(token)) do
       {:ok, %Response{status: status, body: body}} when status in 200..299 ->
         {:ok, Jason.decode!(body)}
 
@@ -172,7 +176,7 @@ defmodule WhatsappElixir.HTTP do
 
     Logger.info("Making GET request to URL: #{url}")
 
-    case Req.get(url, headers: full_headers) do
+    case Req.get(url, decode_body: false, headers: full_headers) do
       {:ok, %Response{status: status, body: body, headers: response_headers}}
       when status in 200..299 ->
         content_type = get_content_type(response_headers)


### PR DESCRIPTION
This PR add `decode_body: false` for Req GET request.

The reasoning and rationale is the same as in https://github.com/Maxino22/whatsapp_elixir/pull/16

For documentation and ease of tracing I am adding #16 description below:
```
Whatsapp incorrectly returned text/javascript instead of application/json as content type, which meant Req would not try to decode it. However, recently Whatsapp seemingly fixed this issue, so now, the already parsed map is passed to Jason.decode! causing it to crash.

To maintain the old behaviour, all we need to do, is make sure Req never attempts to decode the body, regardless of the headers received from Whatsapp, we can do that by setting decode_body to false.
```